### PR TITLE
Updated card header spacing

### DIFF
--- a/src/SmallsOnline.Web.Lib.Components/components/core/AccessDeniedCard.razor
+++ b/src/SmallsOnline.Web.Lib.Components/components/core/AccessDeniedCard.razor
@@ -2,7 +2,7 @@
 
 <div class="card shadow">
     <div class="card-header">
-        <h1>
+        <h1 class="mb-0">
             <i class="bi bi-x-circle-fill text-danger" /> Access Denied
         </h1>
     </div>

--- a/src/SmallsOnline.Web.Lib.Components/components/projects/ProjectCard.razor
+++ b/src/SmallsOnline.Web.Lib.Components/components/projects/ProjectCard.razor
@@ -6,7 +6,7 @@
 {
     <div class="card">
         <div class="card-header">
-            <h3>
+            <h3 class="mb-0">
                 <span class="pe-2">
                     <i class="bi bi-@_projectType!.Icon bi-icon-color-@_projectType!.BaseType" />
                 </span>


### PR DESCRIPTION
To help reduce wasted space in card headers, the title section in the
header now has the bottom margin set to 0.