### PR TITLE
Update BlogEntry to use GenericAttributes extension for HTML

### DIFF
--- a/src/SmallsOnline.Web.Lib/models/blog/BlogEntry.cs
+++ b/src/SmallsOnline.Web.Lib/models/blog/BlogEntry.cs
@@ -75,6 +75,7 @@ public class BlogEntry : IBlogEntry
                 return Markdown.ToHtml(
                     markdown: Content,
                     pipeline: new MarkdownPipelineBuilder()
+                        .UseGenericAttributes()
                         .UsePipeTables()
                         .UseBootstrap()
                         .UseAutoLinks()


### PR DESCRIPTION
Adds the GenericAttributes extension to the MarkdownPipelineBuilder when converting Markdown to HTML.