### PR TITLE
Add YAML metadata to BlogEntry

### DIFF
--- a/src/SmallsOnline.Web.Lib/SmallsOnline.Web.Lib.csproj
+++ b/src/SmallsOnline.Web.Lib/SmallsOnline.Web.Lib.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.30.2" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
YAML metadata can now be read by BlogEntry and fill in the properties.